### PR TITLE
cipher: skip unsupported mechanisms

### DIFF
--- a/cipher.cc
+++ b/cipher.cc
@@ -255,6 +255,13 @@ TEST_P(SecretKeyTest, EncryptDecryptInitInvalid) {
   EXPECT_CKR(CKR_OPERATION_ACTIVE,
              g_fns->C_EncryptInit(session_, &mechanism_, key_.handle()));
 
+  // Finish active operation before starting a new one
+  CK_BYTE ciphertext[1024];
+  CK_ULONG ciphertext_len = sizeof(ciphertext);
+  EXPECT_CKR_OK(g_fns->C_Encrypt(session_,
+                                 plaintext_.get(), kNumBlocks * info_.blocksize,
+                                 ciphertext, &ciphertext_len));
+
   EXPECT_CKR_OK(g_fns->C_DecryptInit(session_, &mechanism_, key_.handle()));
   EXPECT_CKR(CKR_OPERATION_ACTIVE,
              g_fns->C_DecryptInit(session_, &mechanism_, key_.handle()));

--- a/cipher.cc
+++ b/cipher.cc
@@ -233,9 +233,9 @@ TEST_P(SecretKeyTest, EncryptDecryptInitInvalid) {
              g_fns->C_DecryptInit(INVALID_SESSION_HANDLE, &mechanism_, key_.handle()));
 
   EXPECT_CKR(CKR_KEY_HANDLE_INVALID,
-             g_fns->C_EncryptInit(session_, &mechanism, INVALID_OBJECT_HANDLE));
+             g_fns->C_EncryptInit(session_, &mechanism_, INVALID_OBJECT_HANDLE));
   EXPECT_CKR(CKR_KEY_HANDLE_INVALID,
-             g_fns->C_DecryptInit(session_, &mechanism, INVALID_OBJECT_HANDLE));
+             g_fns->C_DecryptInit(session_, &mechanism_, INVALID_OBJECT_HANDLE));
 
   CK_RV rv;
   rv = g_fns->C_EncryptInit(session_, NULL_PTR, key_.handle());

--- a/cipher.cc
+++ b/cipher.cc
@@ -665,10 +665,12 @@ TEST_F(ReadOnlySessionTest, CreateSecretKeyAttributes) {
   ASSERT_CKR_OK(g_fns->C_DestroyObject(session_, key_object));
 }
 
-TEST_F(ReadOnlySessionTest, SecretKeyTestVectors) {
+TEST_F(RWUserSessionTest, SecretKeyTestVectors) {
   for (const auto& kv : kTestVectors) {
     vector<TestData> testcases = kTestVectors[kv.first];
     CipherInfo info = kCipherInfo[kv.first];
+    if (!has_cipher(info, NULL))
+      continue;  /* skip this test */
     for (const TestData& testcase : kv.second) {
       if (g_verbose) {
         cout  << "KEY: " << testcase.key << endl;

--- a/cipher.cc
+++ b/cipher.cc
@@ -422,9 +422,9 @@ TEST_P(SecretKeyTest, DecryptUpdateErrors) {
   CK_BYTE ciphertext[1024];
   CK_ULONG ciphertext_len = sizeof(ciphertext);
   ASSERT_CKR_OK(g_fns->C_EncryptInit(session_, &mechanism_, key_.handle()));
-  ASSERT_CKR_OK(g_fns->C_EncryptUpdate(session_,
-                                       plaintext_.get(), kNumBlocks * info_.blocksize,
-                                       ciphertext, &ciphertext_len));
+  ASSERT_CKR_OK(g_fns->C_Encrypt(session_,
+                                 plaintext_.get(), kNumBlocks * info_.blocksize,
+                                 ciphertext, &ciphertext_len));
 
   // Variety of bad arguments to C_DecryptUpdate.  Each error terminates the
   // operation and so need re-initialization.

--- a/cipher.cc
+++ b/cipher.cc
@@ -509,9 +509,9 @@ TEST_P(SecretKeyTest, DecryptFinalErrors1) {
   CK_BYTE ciphertext[1024];
   CK_ULONG ciphertext_len = sizeof(ciphertext);
   ASSERT_CKR_OK(g_fns->C_EncryptInit(session_, &mechanism_, key_.handle()));
-  ASSERT_CKR_OK(g_fns->C_EncryptUpdate(session_,
-                                       plaintext_.get(), kNumBlocks * info_.blocksize,
-                                       ciphertext, &ciphertext_len));
+  ASSERT_CKR_OK(g_fns->C_Encrypt(session_,
+                                 plaintext_.get(), kNumBlocks * info_.blocksize,
+                                 ciphertext, &ciphertext_len));
 
   // Variety of bad arguments to C_DecryptFinal.  Each error terminates the
   // operation and so need re-initialization.
@@ -533,9 +533,9 @@ TEST_P(SecretKeyTest, DecryptFinalErrors2) {
   CK_BYTE ciphertext[1024];
   CK_ULONG ciphertext_len = sizeof(ciphertext);
   ASSERT_CKR_OK(g_fns->C_EncryptInit(session_, &mechanism_, key_.handle()));
-  ASSERT_CKR_OK(g_fns->C_EncryptUpdate(session_,
-                                       plaintext_.get(), kNumBlocks * info_.blocksize,
-                                       ciphertext, &ciphertext_len));
+  ASSERT_CKR_OK(g_fns->C_Encrypt(session_,
+                                 plaintext_.get(), kNumBlocks * info_.blocksize,
+                                 ciphertext, &ciphertext_len));
 
   CK_BYTE plaintext[1024];
   CK_BYTE_PTR output = plaintext;

--- a/pkcs11test.h
+++ b/pkcs11test.h
@@ -309,7 +309,7 @@ class KeyPair {
 };
 
 // Test fixture for tests involving a secret key.
-class SecretKeyTest : public ReadOnlySessionTest,
+class SecretKeyTest : public RWUserSessionTest,
                       public ::testing::WithParamInterface<std::string> {
  public:
   static const int kNumBlocks = 4;

--- a/pkcs11test.h
+++ b/pkcs11test.h
@@ -249,9 +249,8 @@ class SecretKey {
       attrs_.push_back(valuelen);
     }
     CK_MECHANISM mechanism = {keygen_mechanism, NULL_PTR, 0};
-    EXPECT_CKR_OK(g_fns->C_GenerateKey(session_, &mechanism,
-                                       attrs_.data(), attrs_.size(),
-                                       &key_));
+    rv_ = g_fns->C_GenerateKey(session_, &mechanism, attrs_.data(),
+                               attrs_.size(), &key_);
   }
   ~SecretKey() {
     if (key_ != INVALID_OBJECT_HANDLE) {
@@ -259,11 +258,15 @@ class SecretKey {
     }
   }
   bool valid() const { return (key_ != INVALID_OBJECT_HANDLE); }
-  CK_OBJECT_HANDLE handle() const { return key_; }
+  CK_OBJECT_HANDLE handle() const {
+    EXPECT_CKR_OK(rv_);
+    return key_;
+  }
  private:
   CK_SESSION_HANDLE session_;
   ObjectAttributes attrs_;
   CK_OBJECT_HANDLE key_;
+  CK_RV rv_;
 };
 
 class KeyPair {


### PR DESCRIPTION
While here, cherry-pick a set of upstream cipher test fixes.